### PR TITLE
fix: a systemic pattern across at least 6 files wher... in grinishie.c

### DIFF
--- a/src/gr/grcommon/grinishie.c
+++ b/src/gr/grcommon/grinishie.c
@@ -522,6 +522,15 @@ void grInishieMakePowerBlock(void)
     }
     gGRCommonStruct.inishie.pblock_pos_ids = (u8*) syTaskmanMalloc(pos_count * sizeof(*gGRCommonStruct.inishie.pblock_pos_ids), 0x0);
 
+    if (gGRCommonStruct.inishie.pblock_pos_ids == NULL)
+    {
+        while (TRUE)
+        {
+            syDebugPrintf("PowerBlock pos_ids alloc failed!\n");
+            scManagerRunPrintGObjStatus();
+        }
+    }
+
     mpCollisionGetMapObjIDsKind(nMPMapObjKindPowerBlock, pos_ids);
 
     for (i = 0; i < pos_count; i++)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/gr/grcommon/grinishie.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `src/gr/grcommon/grinishie.c:523` |
| **Assessment** | Confirmed exploitable |

**Description**: A systemic pattern across at least 6 files where syTaskmanMalloc return values are used directly without NULL checks. If the allocator fails due to memory exhaustion, the NULL pointer is immediately dereferenced, causing a crash. This represents a widespread defensive coding gap rather than an isolated issue.

## Changes
- `src/gr/grcommon/grinishie.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
